### PR TITLE
Dependabot for plugin template and child plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-github-dependabot-version-updates
+# https://til.simonwillison.net/github/dependabot-python-setup
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    python-packages:
+      patterns:
+        - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     python-packages:
       patterns:

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -143,6 +143,22 @@ In order to use this option, you must run `git init` once in
 your package's root directory.
 ```
 
+## install_precommit
+
+The default for this prompt is `"n"`.
+
+If you choose "y" for this prompt, then [pre-commit](ttps://pre-commit.com/) will be installed.
+Among other things, it includes checks for code linting and best practices in napari plugins.
+
+## install_dependabot
+
+The default for this prompt is `"n"`.
+
+If you choose "y" for this prompt, then a [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration file will be created at `.github/dependabot.yml`.
+
+You will still need to enable Dependabot in your github settings, [see the instructions at this link](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories).
+
+
 ## license
 
 This prompt allows you to choose from a variety of open source licensing options

--- a/README.md
+++ b/README.md
@@ -107,12 +107,6 @@ git commit -m 'initial commit'
    git push -u origin main
    ```
 
-### Enable Dependabot security updates
-
-You can use [Dependabot](https://docs.github.com/en/code-security/dependabot) security updates to easily update vulnerable dependencies.
-
-[Here's how to enable Dependabot in your github settings](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories). Your Dependabot configuration file is located at `.github/dependabot.yml`.
-
 ### Monitor testing and coverage
 
 The repository should already be setup to run your tests each time you push an
@@ -220,6 +214,12 @@ pre-commit install
 
 You can also have these checks run automatically for you when you push to github
 by installing [pre-commit ci](https://pre-commit.ci/) on your repository.
+
+## Dependabot
+
+This template also includes a default yaml configuration for [Dependabot](https://docs.github.com/en/code-security/dependabot). This can help you check for security updates to easily update vulnerable dependencies.
+
+You will still need to enable Dependabot in your github settings, [see the instructions at this link](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories). Your Dependabot configuration file is located at `.github/dependabot.yml`.
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ git commit -m 'initial commit'
    git push -u origin main
    ```
 
+### Enable Dependabot security updates
+
+You can use [Dependabot](https://docs.github.com/en/code-security/dependabot) security updates to easily update vulnerable dependencies.
+
+[Here's how to enable Dependabot in your github settings](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories). Your Dependabot configuration file is located at `.github/dependabot.yml`.
+
 ### Monitor testing and coverage
 
 The repository should already be setup to run your tests each time you push an

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,6 +13,7 @@
     "include_widget_plugin": "y",
     "use_git_tags_for_versioning": "n",
     "install_precommit": "n",
+    "install_dependabot": "n",
     "license": [
         "BSD-3",
         "MIT",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -32,6 +32,10 @@ def remove_unrequested_plugin_examples():
     remove_file(f"src/{module}/_{name}.py")
     remove_file(f"src/{module}/_tests/test_{name}.py")
     logger.debug(f"removing {module}/_{name}.py")
+    # remove dependabot config if unrequested
+    {% elif key.startswith("install_dependabot") and value != 'y' %}
+    remove_file(".github/dependabot.yml")
+    logger.debug("removeing .github/dependabot.yml")
     {% endif %}
     {% endfor %}
 

--- a/{{cookiecutter.plugin_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.plugin_name}}/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
 - package-ecosystem: pip
   directory: "/"
   schedule:
-    interval: weekly
+    interval: monthly
   groups:
     python-packages:
       patterns:

--- a/{{cookiecutter.plugin_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.plugin_name}}/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-github-dependabot-version-updates
+# https://til.simonwillison.net/github/dependabot-python-setup
+{% raw %}
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    python-packages:
+      patterns:
+        - "*"
+{% endraw %}


### PR DESCRIPTION
[Dependabot](https://docs.github.com/en/code-security/dependabot) is a useful tool for security updates of dependencies. 

It benefits our wider napari plugin ecosystem to make it as easy as possible to keep plugins up to date, and free from known security vulnerabilities.

This PR:
* Adds a `.github/dependabot.yml` file, to run dependabot on the cookiecutter template repo.
* Adds a `{{cookiecutter.plugin_name}}/.github/dependabot.yml` file, to run dependabot on the child plugin repo.
* Adds a section to the cookiecutter `README.md`, explaining [how to enable dependabot in your github settings](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories)

I modeled the `.github/dependabot.yml` files on the python example here:  https://til.simonwillison.net/github/dependabot-python-setup

Xref: https://github.com/napari/cookiecutter-napari-plugin/pull/184 (both this PR and the other one are generated from the exact same branch)