### PR TITLE
Synchronize main branch of cookiecutter-napari-plugin with this repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-github-dependabot-version-updates
+# https://til.simonwillison.net/github/dependabot-python-setup
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: monthly
+  groups:
+    python-packages:
+      patterns:
+        - "*"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,6 @@ jobs:
           python -m pip install pytest pytest-cookies tox
 
       - name: Test
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         with:
           run: python -m pytest -s -v --color=yes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.9, "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -143,6 +143,22 @@ In order to use this option, you must run `git init` once in
 your package's root directory.
 ```
 
+## install_precommit
+
+The default for this prompt is `"n"`.
+
+If you choose "y" for this prompt, then [pre-commit](ttps://pre-commit.com/) will be installed.
+Among other things, it includes checks for code linting and best practices in napari plugins.
+
+## install_dependabot
+
+The default for this prompt is `"n"`.
+
+If you choose "y" for this prompt, then a [Dependabot](https://docs.github.com/en/code-security/dependabot) configuration file will be created at `.github/dependabot.yml`.
+
+You will still need to enable Dependabot in your github settings, [see the instructions at this link](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories).
+
+
 ## license
 
 This prompt allows you to choose from a variety of open source licensing options

--- a/README.md
+++ b/README.md
@@ -215,6 +215,12 @@ pre-commit install
 You can also have these checks run automatically for you when you push to github
 by installing [pre-commit ci](https://pre-commit.ci/) on your repository.
 
+## Dependabot
+
+This template also includes a default yaml configuration for [Dependabot](https://docs.github.com/en/code-security/dependabot). This can help you check for security updates to easily update vulnerable dependencies.
+
+You will still need to enable Dependabot in your github settings, [see the instructions at this link](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories). Your Dependabot configuration file is located at `.github/dependabot.yml`.
+
 ## Features
 
 - Installable [PyPI] package

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -13,6 +13,7 @@
     "include_widget_plugin": "y",
     "use_git_tags_for_versioning": "n",
     "install_precommit": "n",
+    "install_dependabot": "n",
     "license": [
         "BSD-3",
         "MIT",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -32,6 +32,10 @@ def remove_unrequested_plugin_examples():
     remove_file(f"src/{module}/_{name}.py")
     remove_file(f"src/{module}/_tests/test_{name}.py")
     logger.debug(f"removing {module}/_{name}.py")
+    # remove dependabot config if unrequested
+    {% elif key.startswith("install_dependabot") and value != 'y' %}
+    remove_file(".github/dependabot.yml")
+    logger.debug("removing .github/dependabot.yml")
     {% endif %}
     {% endfor %}
 

--- a/{{cookiecutter.plugin_name}}/.github/dependabot.yml
+++ b/{{cookiecutter.plugin_name}}/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-github-dependabot-version-updates
+# https://til.simonwillison.net/github/dependabot-python-setup
+{% raw %}
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: monthly
+  groups:
+    python-packages:
+      patterns:
+        - "*"
+{% endraw %}

--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -55,7 +55,7 @@ jobs:
 
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        uses: aganders3/headless-gui@v1
+        uses: aganders3/headless-gui@v2
         with:
           run: python -m tox
         env:

--- a/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
+++ b/{{cookiecutter.plugin_name}}/.github/workflows/test_and_deploy.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -75,9 +75,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.dynamic]
-version = {attr = "{{cookiecutter.module_name}}.__init__.__version__"}
-
 [tool.setuptools.packages.find]
 where = ["src"]
 
@@ -87,6 +84,9 @@ where = ["src"]
 {% if cookiecutter.use_git_tags_for_versioning == 'y' and cookiecutter.plugin_name != "foo-bar" %}
 [tool.setuptools_scm]
 write_to = "src/{{cookiecutter.module_name}}/_version.py"
+{% else %}
+[tool.setuptools.dynamic]
+version = {attr = "{{cookiecutter.module_name}}.__init__.__version__"}
 {%- endif %}
 
 [tool.black]

--- a/{{cookiecutter.plugin_name}}/pyproject.toml
+++ b/{{cookiecutter.plugin_name}}/pyproject.toml
@@ -65,7 +65,7 @@ testing = [
 {%- endif %}
 
 [build-system]
-{% if cookiecutter.use_git_tags_for_versioning == 'y' and cookiecutter.plugin_name != "foo-bar" -%}
+{% if cookiecutter.use_git_tags_for_versioning == 'y' -%}
 requires = ["setuptools>=42.0.0", "wheel", "setuptools_scm"]
 {%- else -%}
 requires = ["setuptools>=42.0.0", "wheel"]
@@ -81,7 +81,7 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
 
-{% if cookiecutter.use_git_tags_for_versioning == 'y' and cookiecutter.plugin_name != "foo-bar" %}
+{% if cookiecutter.use_git_tags_for_versioning == 'y' %}
 [tool.setuptools_scm]
 write_to = "src/{{cookiecutter.module_name}}/_version.py"
 {% else %}


### PR DESCRIPTION
Unfortunately keeping two near-identical repositories open at the same time (cookiecutter-napari-plugin and napari-plugin-template) has led to them slightly diverging.

This pull request is to synchronise the state of the main branch, before switching over to using copier (see https://github.com/napari/napari-plugin-template/pull/7)