### PR TITLE
Fix tox.ini by updating python versions and adding jinja extension

### DIFF
--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -1,14 +1,14 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{39,310,311,312}-{linux,macos,windows}
+envlist = py{310,311,312,313}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Closes #27 

1. add jinja extension
2. use py310-313 instead of py39-312

Now properly inherits module name

Tested locally 👍 