### PR TITLE
Improve copier prompts, defaults, and use the project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,17 @@ the [prompts reference](./PROMPTS.md).
 ```sh
 copier copy --trust https://github.com/napari/napari-plugin-template napari-growth-cone-finder
 
-🎤 The name of your plugin
+Welcome to the napari plugin template!
+This template will help you create a new napari plugin with all the necessary structure of a Python package. 
+
+For more detailed information about each prompt, see:
+https://github.com/napari/napari-plugin-template/blob/main/PROMPTS.md
+
+🎤 The name of your plugin, used to name the package and repository
    napari-growth-cone-finder
-🎤 Display name for your plugin
+🎤 Display name for your plugin in the napari GUI
    Growth Cone Finder
-🎤 Plugin module name
+🎤 Plugin module name, usually the same as the name of the package, but lowercase and with underscores
    napari_growth_cone_finder
 🎤 Short description of what your plugin does
    A simple plugin for napari

--- a/_tasks.py
+++ b/_tasks.py
@@ -61,6 +61,7 @@ def validate_manifest(module_name, project_directory):
 def initialize_new_repository(
     install_precommit=False,
     plugin_name='napari-foobar',
+    plugin_directory='napari-foobar',
     github_repository_url='provide later',
     github_username_or_organization='githubuser',
 ):
@@ -106,7 +107,7 @@ def initialize_new_repository(
 Your plugin template is ready!  Next steps:
 1. `cd` into your new directory and initialize a git repo
 (this is also important for version control!)
-    cd {plugin_name}
+    cd {plugin_directory}
     git init -b main
     git add .
     git commit -m 'initial commit'
@@ -117,7 +118,7 @@ Your plugin template is ready!  Next steps:
         msg += f"""
 Your plugin template is ready!  Next steps:
 1. `cd` into your new directory
-    cd {plugin_name}
+    cd {plugin_directory}
     # you probably want to install your new package into your env
     pip install -e .
 """
@@ -220,6 +221,7 @@ if __name__ == '__main__':
     msg = initialize_new_repository(
         install_precommit=install_precommit,
         plugin_name=args.plugin_name,
+        plugin_directory=args.project_directory,
         github_repository_url=args.github_repository_url,
         github_username_or_organization=args.github_username_or_organization,
     )

--- a/copier.yaml
+++ b/copier.yaml
@@ -24,7 +24,7 @@ display_name:
         {% endif %}
 module_name:
     default: "{{ plugin_name|lower|replace('-', '_') }}"
-    help: Plugin module name. Usually the same as the name of the plugin package, but lowercase and with underscores
+    help: Plugin module name, usually the same as the name of the plugin package, but lowercase and with underscores
     type: str
     validator: >-
         {% if not (module_name | regex_search("^[a-z][_a-z0-9]+$")) %}

--- a/copier.yaml
+++ b/copier.yaml
@@ -1,35 +1,43 @@
+_message_before_copy: |
+
+    Welcome to the napari plugin template!
+    This template will help you create a new napari plugin with all the necessary structure of a Python package. 
+
+    For more detailed information about each prompt, see:
+    https://github.com/napari/napari-plugin-template/blob/main/PROMPTS.md
+
 plugin_name:
-    placeholder: napari-foobar
-    help: The name of your plugin
+    default: "{{ _copier_conf.dst_path | basename }}"
+    help: The name of your plugin, used to name the package and repository
     type: str
     validator: >-
         {% if not (plugin_name | regex_search('^[a-z][a-z0-9\-]+$')) %}
         plugin_name must be lowercase, no spaces, and may contain hyphens.
         {% endif %}
 display_name:
-    placeholder: FooBar Segmentation
-    help: Display name for your plugin
+    default: "{{ plugin_name|lower|replace('napari-', '')|title|replace('-', ' ') }}"
+    help: Display name for your plugin in the napari GUI
     type: str
     validator: >-
         {% if not (display_name | regex_search('(.|\s)*\S(.|\s)*')) %}
         display_name must not be empty
         {% endif %}
 module_name:
-    placeholder: "{{ plugin_name|lower|replace('-', '_') }}"
-    help: Plugin module name
+    default: "{{ plugin_name|lower|replace('-', '_') }}"
+    help: Plugin module name. Usually the same as the name of the plugin package, but lowercase and with underscores
     type: str
     validator: >-
         {% if not (module_name | regex_search("^[a-z][_a-z0-9]+$")) %}
         module_name must be lowercase, and may contain underscores
         {% endif %}
 short_description:
-    placeholder: A simple plugin to use FooBar segmentation within napari
+    placeholder: A simple plugin to use {{ display_name }} within napari
     help: Short description of what your plugin does
     type: str
     validator: >-
         {% if not (short_description | regex_search('(.|\s)*\S(.|\s)*')) %}
         short_description must not be empty
-        {% endif %}
+        {% endif %} 
 email:
     placeholder: yourname@example.com
     help: Email address


### PR DESCRIPTION
Improves copier prompting in the following ways (addressing some items in #23):

1. Uses copier destination directory as plugin name 
2. Gets rid of all 'foobar' references and instead uses plugin name, etc as source of defaults
3. Uses defaults instead of placeholder in some initial prompts
4. Improves help text of many prompts
6. Uses plugin directory for `cd` instructions in post-prompt tasks, in case a user created in subdirectory
7. Updates readme to be consistent with this change


Thank you @pearsomark for your contribution in #19, it was helpful when making this -- and it's awesome that it is your first contribution to napari! (@willingc is it possible for me to add them as an author? I tried but since I don't know their e-mail it doesn't seem to be working. 