### PR TITLE
Fix default plugin name in copier.yaml to handle undefined _copier_conf

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -7,7 +7,7 @@ _message_before_copy: |
     https://github.com/napari/napari-plugin-template/blob/main/PROMPTS.md
 
 plugin_name:
-    default: "{{ _copier_conf.dst_path | basename }}"
+    default: "{{ _copier_conf.dst_path | basename if _copier_conf is defined else 'my-napari-plugin' }}"
     help: The name of your plugin, used to name the package and repository
     type: str
     validator: >-


### PR DESCRIPTION
Closes #40. 

Within the last day, copier v9.6.0 release removed ability to use `_copier_conf` variables in questions. To continue smoothly allowing our template to work, this adds a conditional statement that will use a default value `my-napari-plugin` for the plugin_name if the _copier_conf variables can't be accessed during template question.

I have tested that this fixes the issue locally. I will revisit this statement once we know the [response on copier's end](https://github.com/copier-org/copier/issues/2021) if this is intentional or not. This PR hopes that copier will fix this break, or provide an alternative solution. 