### PR TITLE
Pin copier to a sha to pull in fixes from upstream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-copier
+# pin copier to a sha until they do next release
+copier@git+https://github.com/copier-org/copier@4fb26fe25bd01b210e77def622cf0de3b354875a
 jinja2-time
 npe2
 pytest


### PR DESCRIPTION
This PR pins copier installation to a SHA that was tested by @psobolewskiPhD.

This is a temporary fix to #40.
