### PR TITLE
Drop SIM117 rule in lint.ignore for pyproject template

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -111,7 +111,6 @@ lint.select = [
 lint.ignore = [
     "E501", # line too long. let black handle this
     "UP006", "UP007", # type annotation. As using magicgui require runtime type annotation then we disable this.
-    "SIM117", # flake8-simplify - some of merged with statements are not looking great with black, reanble after drop python 3.9
 ]
 
 exclude = [


### PR DESCRIPTION
I noticed this comment suggested to remove SIM117 from lint.ignore when python 3.9 was dropped. Since we have done so, this PR removes that rule. 