### PR TITLE
Make git tags (and setuptool_scm) the only versioning option

### DIFF
--- a/PROMPTS.md
+++ b/PROMPTS.md
@@ -115,34 +115,6 @@ the code in this file to achieve the dock widget functionality you want. For
 more information on dock widgets see the
 [specification reference][widget-spec].
 
-## use_git_tags_for_versioning
-
-The default for this prompt is `"y"`. If you choose `"n"` for this prompt, you
-will have to manually manage your version numbers when you create new releases
-of your package. You can do this in `pyproject.toml` under the `version` field (you
-will also need to update the version string wherever else you may have used it
-in your package, such as in `__init__.py`). Choosing `"n"` at this prompt will
-add `version = 0.0.1` to your `pyproject.toml`.
-
-If you choose `"y"` for this prompt, your package will be set up to have
-[`setuptools_scm`](https://github.com/pypa/setuptools_scm) manage versions for
-you based on your git tags. See the
-[readme](https://github.com/napari/napari-plugin-template#automatic-deployment-and-version-management)
-for details.
-
-This option typically requires the least effort to manage versioning for your
-package, and will prevent errors with manually managed version strings going out
-of sync with your package metadata. The main downside is that your users will
-not be able to install directly from a github release asset, and will need to
-have git installed if they want to directly install from a git repository.
-(This does _not_, however, affect the standard method of installing with `pip`, or
-installing from a pre-packaged wheel file.)
-
-```{note}
-In order to use this option, you must run `git init` once in
-your package's root directory.
-```
-
 ## install_precommit
 
 The default for this prompt is `"y"`.

--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ https://github.com/napari/napari-plugin-template/blob/main/PROMPTS.md
    Yes
 🎤 Include widget plugin?
    Yes
-🎤 Use git tags for automatic versioning?
-   Yes
 🎤 Install pre-commit? (Code formatting checks)
    Yes
 🎤 Install dependabot? (Automatic security updates of dependency versions)

--- a/copier.yaml
+++ b/copier.yaml
@@ -73,10 +73,6 @@ include_widget_plugin:
     default: true
     help: Include widget plugin?
     type: bool
-use_git_tags_for_versioning:
-    default: true
-    help: Use git tags for automatic versioning?
-    type: bool
 install_precommit:
     default: true
     help: Install pre-commit? (Code formatting checks)

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -65,11 +65,7 @@ testing = [
 {%- endif %}
 
 [build-system]
-{% if use_git_tags_for_versioning -%}
 requires = ["setuptools>=42.0.0", "wheel", "setuptools_scm"]
-{%- else -%}
-requires = ["setuptools>=42.0.0", "wheel"]
-{%- endif %}
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -81,14 +77,9 @@ where = ["src"]
 [tool.setuptools.package-data]
 "*" = ["*.yaml"]
 
-{% if use_git_tags_for_versioning %}
 [tool.setuptools_scm]
 write_to = "src/{{module_name}}/_version.py"
 fallback_version = "0.0.1+nogit"
-{% else %}
-[tool.setuptools.dynamic]
-version = {attr = "{{module_name}}.__init__.__version__"}
-{%- endif %}
 
 [tool.black]
 line-length = 79

--- a/template/src/{{module_name}}/__init__.py.jinja
+++ b/template/src/{{module_name}}/__init__.py.jinja
@@ -1,11 +1,7 @@
-{% if use_git_tags_for_versioning %}
 try:
     from ._version import version as __version__
 except ImportError:
     __version__ = "unknown"
-{% else -%}
-__version__ = "0.0.1"
-{% endif -%}
 
 {% if include_reader_plugin %}
 from ._reader import napari_get_reader


### PR DESCRIPTION
With #47 merged and related discussion in #46, `fallback_version` for `setuptools-scm` should make it so that there is no need to have optional manual versioning. Manual versioning is important if someone downloaded the source code without a git tag attached, such as the .zip from github and tried to install it via something like napari-plugin-manager. With the fallback_version, this .zip-style installation should now work. Therefore, for simplicity and modern best-practices we should default to making git tags the default and only option for versioning. The README is also already written under the assumption that git tags is the way versioning is done. 