### PR TITLE
Add main and template issue forms

### DIFF
--- a/.github/ISSSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: "\U0001F41B Bug Report"
+description: Report a bug encountered while using napari-plugin-template
+labels:
+  - "bug"
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this issue! 🙏🏼
+
+        Please fill out the sections below to help us reproduce the problem.
+
+  - type: textarea
+    id: bug-report
+    attributes:
+      label: "\U0001F41B Bug Report"
+      description: "Please provide a clear and concise description of the bug."
+      placeholder: "What went wrong? What did you expect to happen?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: "\U0001F4A1 Steps to Reproduce"
+      description: "Please provide a minimal code snippet or list of steps to reproduce the bug."
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "\U0001F4A1 Expected Behavior"
+      description: "Please provide a clear and concise description of what you expected to happen."
+      placeholder: "What did you expect to happen?"
+
+  - type: textarea
+    id: additional-context
+    attributes:
+        label: "\U0001F4A1 Additional Context"
+        description: "Please provide any additional information or context regarding the problem here."
+        placeholder: "Add any other context about the problem here."

--- a/.github/ISSSUE_TEMPLATE/documentation.md
+++ b/.github/ISSSUE_TEMPLATE/documentation.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F4DA Documentation"
+about: Report an issue with napari-plugin-template documentation
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+## 📚 Documentation
+<!-- A clear and concise description of the documentation that needs to be created/updated -->

--- a/.github/ISSSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: "\U0001F680 Feature Request"
+about: Submit a proposal/request for a new napari-plugin-template feature
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+## 🚀 Feature
+<!-- A clear and concise description of the feature proposal -->
+
+## Motivation
+
+<!-- Please outline the motivation for the proposal. Is your feature request related to a problem? e.g., I'm always frustrated when [...]. If this is related to another GitHub issue, please link here too -->
+
+## Pitch
+
+<!-- A clear and concise description of what you want to happen. -->
+
+## Alternatives
+
+<!-- A clear and concise description of any alternative solutions or features you've considered, if any. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSSUE_TEMPLATE/task.md
+++ b/.github/ISSSUE_TEMPLATE/task.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F9F0 Task"
+about: Maintenance, follow-ups, and other defined to-do items
+title: ''
+labels: task
+assignees: ''
+
+---
+
+## 🧰 Task
+<!-- A clear and concise description of the task -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# References and relevant issues
+<!-- What relevant resources were used in the creation of this PR?
+If this PR addresses an existing issue on the repo,
+please link to that issue here as "Closes #(issue-number)"
+If this PR depends on another PR/issue (even in another repo),
+please link to it with "Depends on #PR-number" or "Depends on org/repo#PR-number"
+-->
+
+# Description
+<!-- What does this pull request (PR) do? Is it a new feature, a bug fix,
+an improvement, or something else? Why is it necessary? If relevant, please add
+a screenshot or a screen capture: "An image is worth a thousand words!" -->

--- a/template/.github/ISSUE_TEMPLATE/bug_report.yml.jinja
+++ b/template/.github/ISSUE_TEMPLATE/bug_report.yml.jinja
@@ -1,0 +1,87 @@
+name: "\U0001F41B Bug Report"
+description: Report a bug encountered while using {{ plugin_name }}
+labels:
+  - "bug"
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this issue! 🙏🏼
+
+        Please fill out the sections below to help us reproduce the problem.
+
+  - type: textarea
+    id: bug-report
+    attributes:
+      label: "\U0001F41B Bug Report"
+      description: "Please provide a clear and concise description of the bug."
+      placeholder: "What went wrong? What did you expect to happen?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: "\U0001F4A1 Steps to Reproduce"
+      description: "Please provide a minimal code snippet or list of steps to reproduce the bug."
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "\U0001F4A1 Expected Behavior"
+      description: "Please provide a clear and concise description of what you expected to happen."
+      placeholder: "What did you expect to happen?"
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: "\U0001F30E Environment"
+      description: |
+        Please provide detailed information regarding your environment. Please paste the output of `napari --info` here or copy  the information from the "napari info" dialog in the napari Help menu.
+
+        Otherwise, please provide information regarding your operating system (OS), Python version, napari version, Qt backend and version, Qt platform, method of installation, and any other relevant information related to your environment.
+
+
+      placeholder: |
+        napari: 0.5.0
+        Platform: macOS-13.2.1-arm64-arm-64bit
+        System: MacOS 13.2.1
+        Python: 3.11.4 (main, Aug 7 2023, 20:34:01) [Clang 14.0.3 (clang-1403.0.22.14.1)]
+        Qt: 5.15.10
+        PyQt5: 5.15.10
+        NumPy: 1.25.1
+        SciPy: 1.11.1
+        Dask: 2023.7.1
+        VisPy: 0.13.0
+        magicgui: 0.7.2
+        superqt: 0.5.4
+        in-n-out: 0.1.8
+        app-model: 0.2.0
+        npe2: 0.7.2
+
+        OpenGL:
+        - GL version: 2.1 Metal - 83
+        - MAX_TEXTURE_SIZE: 16384
+
+        Screens:
+        - screen 1: resolution 1512x982, scale 2.0
+
+        Settings path:
+        - /Users/.../napari/napari_5c6993c40c104085444cfc0c77fa392cb5cb8f56/settings.yaml
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-context
+    attributes:
+        label: "\U0001F4A1 Additional Context"
+        description: "Please provide any additional information or context regarding the problem here."
+        placeholder: "Add any other context about the problem here."

--- a/template/.github/ISSUE_TEMPLATE/documentation.md.jinja
+++ b/template/.github/ISSUE_TEMPLATE/documentation.md.jinja
@@ -1,0 +1,11 @@
+---
+name: "\U0001F4DA Documentation"
+about: Report an issue with {{ plugin_name }} documentation
+title: ''
+labels: documentation
+assignees: ''
+
+---
+
+## 📚 Documentation
+<!-- A clear and concise description of the documentation that needs to be created/updated -->

--- a/template/.github/ISSUE_TEMPLATE/feature_request.md.jinja
+++ b/template/.github/ISSUE_TEMPLATE/feature_request.md.jinja
@@ -1,0 +1,27 @@
+---
+name: "\U0001F680 Feature Request"
+about: Submit a proposal/request for a new {{ plugin_name }} feature
+title: ''
+labels: feature
+assignees: ''
+
+---
+
+## 🚀 Feature
+<!-- A clear and concise description of the feature proposal -->
+
+## Motivation
+
+<!-- Please outline the motivation for the proposal. Is your feature request related to a problem? e.g., I'm always frustrated when [...]. If this is related to another GitHub issue, please link here too -->
+
+## Pitch
+
+<!-- A clear and concise description of what you want to happen. -->
+
+## Alternatives
+
+<!-- A clear and concise description of any alternative solutions or features you've considered, if any. -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/template/.github/ISSUE_TEMPLATE/task.md
+++ b/template/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,11 @@
+---
+name: "\U0001F9F0 Task"
+about: Maintenance, follow-ups, and other defined to-do items
+title: ''
+labels: task
+assignees: ''
+
+---
+
+## 🧰 Task
+<!-- A clear and concise description of the task -->

--- a/template/.github/PULL_REQUEST_TEMPLATE.md
+++ b/template/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+# References and relevant issues
+<!-- What relevant resources were used in the creation of this PR?
+If this PR addresses an existing issue on the repo,
+please link to that issue here as "Closes #(issue-number)"
+If this PR depends on another PR/issue (even in another repo),
+please link to it with "Depends on #PR-number" or "Depends on org/repo#PR-number"
+-->
+
+# Description
+<!-- What does this pull request (PR) do? Is it a new feature, a bug fix,
+an improvement, or something else? Why is it necessary? If relevant, please add
+a screenshot or a screen capture: "An image is worth a thousand words!" -->


### PR DESCRIPTION
Adds templates based on napari/napari for both the main repo and the template itself.

This will add a level of familiarity to link napari users/developers to plugin users/developers. Overall should ease contribution all around, based on experience. 