### PR TITLE
Update README.md.jinja to use code fencing for install instructions

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -27,16 +27,23 @@ https://napari.org/stable/plugins/index.html
 
 You can install `{{plugin_name}}` via [pip]:
 
-    pip install {{plugin_name}}
+```
+pip install {{plugin_name}}
+```
 
 If napari is not already installed, you can install `{{plugin_name}}` with napari and Qt via:
 
-    pip install "{{plugin_name}}[all]"
+```
+pip install "{{plugin_name}}[all]"
+```
 
 {% if github_repository_url != 'provide later' %}
 To install latest development version :
 
-    pip install git+https://github.com/{{github_username_or_organization}}/{{plugin_name}}.git
+```
+pip install git+https://github.com/{{github_username_or_organization}}/{{plugin_name}}.git
+```
+
 {% endif %}
 
 ## Contributing


### PR DESCRIPTION
I noticed plugins on the new lite-hub have some odd display of the installation instructions:
https://napari.org/hub-lite/plugins/napari-skimage.html

<img width="868" alt="image" src="https://github.com/user-attachments/assets/d8b81968-ad39-4c25-9616-c3b0a2f2a6aa" />

Looking at the README files, it's because those impossible to see lines are not code fenced, just indented. Looks like GitHub is fine with this, even though I don't think it's proper markdown, but hub-lite not so much.
I thought this was very odd usage and ultimately the pattern being so similar between so many plugins led me to this repo.

I've seen other copier project templates use code fencing in the README.md.jinja so I think this shouldn't break anything.