### PR TITLE
add community meeting schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ simplify the development and distribution your plugin.
 > If you are interested in creating a plugin, have any questions about the process, or simply want to show
 off your progress, we encourage you to post on the [Zulip chat](napari.zulipchat.com), where the core team
 and the napari community are always active and happy to give you feedback!
-> Would you rather directly talk to some of the core team to maybe solve some of your issues live or get answers 
-directly? We have the napari community meetings for that! Check [here](https://napari.org/stable/community/meeting_schedule.html)
-for the schedule to see which meeting time suits you. Your plugin is not finished yet? Don't worry, you can also just 
-join even though your plugin is not complete. The earlier you join, the better. We are there to help!
+> You can also talk directly to some of the core team at the napari community meetings; check [here](https://napari.org/stable/community/meeting_schedule.html)
+for the schedule to see which meeting time suits you. Don't worry if your plugin is not finished yet, the earlier you join, the better! We are there to help :)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ off your progress, we encourage you to post on the [Zulip chat](napari.zulipchat
 and the napari community are always active and happy to give you feedback!
 > Would you rather directly talk to some of the core team to maybe solve some of your issues live or get answers 
 directly? We have the napari community meetings for that! Check [here](https://napari.org/stable/community/meeting_schedule.html)
-for the schedule to see which meeting time suits you. Don't worry, you can also just join even though your plugin
-is not complete. We are there to help!
+for the schedule to see which meeting time suits you. Your plugin is not finished yet? Don't worry, you can also just 
+join even though your plugin is not complete. The earlier you join, the better. We are there to help!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ simplify the development and distribution your plugin.
 > If you are interested in creating a plugin, have any questions about the process, or simply want to show
 off your progress, we encourage you to post on the [Zulip chat](napari.zulipchat.com), where the core team
 and the napari community are always active and happy to give you feedback!
+> Would you rather directly talk to some of the core team to maybe solve some of your issues live or get answers 
+directly? We have the napari community meetings for that! Check [here](https://napari.org/stable/community/meeting_schedule.html)
+for the schedule to see which meeting time suits you. Don't worry, you can also just join even though your plugin
+is not complete. We are there to help!
 
 ---
 


### PR DESCRIPTION
# Description
This PR adds to the recent changes of @brisvag, by adding information regarding the community meetings where people can join to get direct feedback or get direct answers based on questions that they have. The message also includes that it is ok if the plugin is not complete.
