### PR TITLE
Remove default categories from napari.yaml

### DIFF
--- a/template/src/{{module_name}}/napari.yaml.jinja
+++ b/template/src/{{module_name}}/napari.yaml.jinja
@@ -3,7 +3,7 @@ display_name: {{display_name}}
 # use 'hidden' to remove plugin from napari hub search results
 visibility: public
 # see https://napari.org/stable/plugins/technical_references/manifest.html#fields for valid categories
-categories: ["Annotation", "Segmentation", "Acquisition"]
+# categories: []
 contributions:
   commands:{% if include_reader_plugin %}
     - id: {{plugin_name}}.get_reader


### PR DESCRIPTION
By default, three categories are given to `napari.yaml` that might not be appropriate for the plugin. This PR removes those categories, but keeps this information as a comment to prompt plugin creators to add categories appropriate to their plugin. This prevents new plugins be categorized the same if an author does not update this field. 


