### PR TITLE
Use trusted publishing to simplify deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,20 +359,15 @@ to install the codecov github app and give it access to your napari plugin repos
 ### Set up automatic deployments
 
 Your new package is also nearly ready to automatically deploy to [PyPI]
-(whenever you create a tagged release), so that your users can simply `pip install` your package. You just need to create an [API token to authenticate
-with PyPi](https://pypi.org/help/#apitoken), and then add it to your github
-repository:
+(whenever you create a tagged release), so that your users can simply `pip install` your package. 
+We now use the newer [trusted OIDC publishing](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/) method for PyPI; no API token is needed.
 
 1. If you don't already have one, [create an
    account](https://pypi.org/account/register/) at [PyPI]
-2. Verify your email address with PyPI, (if you haven't already)
-3. Generate an [API token](https://pypi.org/help/#apitoken) at PyPi: In your
-   [account settings](https://pypi.org/manage/account/) go to the API tokens
-   section and select "Add API token". Make sure to copy it somewhere safe!
-4. [Create a new encrypted
-   secret](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets#creating-encrypted-secrets)"
-   in your github repository with the name "TWINE_API_KEY", and paste in your
-   API token.
+2. Verify your email address with PyPI, (if you haven't already) and add
+   2FA authentication to your account.
+3. Add a new pending publisher. Go to Account Settings > Publishing.
+   Scroll down to add a new pending publisher and enter in the requested details.
 
 You are now setup for automatic deployment!
 

--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -70,21 +70,19 @@ jobs:
     needs: [test]
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - name: Install dependencies
+      - name: Build package
         run: |
           python -m pip install --upgrade pip
           pip install -U setuptools setuptools_scm wheel twine build
-      - name: Build and publish
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.TWINE_API_KEY }}
-        run: |
           git tag
           python -m build .
-          twine upload dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# References and relevant issues

One of the most difficult things for me when starting was adding an API key to publish to PyPI. Even today, it's one of the most tedious parts of publishing a package. 

This PR instead uses the newer OIDC trusted publishing through PyPI which requires no API Key. Instead, you add a new pending publisher via your PyPI account. This is more secure _and_ simpler than before! 

I have tested this today with a new plugin to ensure it works correctly. :)
