### PR TITLE
Genereate .copier-answer.yml and add template tag to README

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -13,7 +13,7 @@
 
 ----------------------------------
 
-This [napari] plugin was generated with [copier] using the [napari-plugin-template] (v{{ _copier_conf._commit or 'main' }}).
+This [napari] plugin was generated with [copier] using the [napari-plugin-template] ({{ _copier_conf.vcs_ref or _copier_conf.src_path or 'development' }}).
 
 <!--
 Don't miss the full getting started guide to set up your new package:

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -13,7 +13,7 @@
 
 ----------------------------------
 
-This [napari] plugin was generated with [copier] using the [napari-plugin-template] ({{ _copier_conf.vcs_ref or _copier_conf.src_path or 'development' }}).
+This [napari] plugin was generated with [copier] using the [napari-plugin-template] ({{ _copier_conf.vcs_ref }}).
 
 <!--
 Don't miss the full getting started guide to set up your new package:

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -13,7 +13,7 @@
 
 ----------------------------------
 
-This [napari] plugin was generated with [copier] using the [napari-plugin-template].
+This [napari] plugin was generated with [copier] using the [napari-plugin-template] (v{{ _copier_conf._commit or 'main' }}).
 
 <!--
 Don't miss the full getting started guide to set up your new package:

--- a/template/{{ _copier_conf.answers_file }}.jinja
+++ b/template/{{ _copier_conf.answers_file }}.jinja
@@ -1,0 +1,2 @@
+# Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
+{{ _copier_answers|to_nice_yaml -}}


### PR DESCRIPTION
# Description

This genarates the `.copier-answer.yml` file which I've been debating on adding for a while. My hesitation is adding yet another file into the template's output, but I'm realizing a few strengths:
1. authors can validate how they set up a project, and use that in a new project, if they find it helpful
2. support, like from the napari team, will be easier because we can see what the project started with, in order to narrow down changes
3. it allows re-running templates and updating, by basing on previous answers or 'resetting'

This also adds the `vcs_ref` (tag or dev version) to the template output, so that, again, it's easier to support plugin authors. 
