### PR TITLE
Remove wheel as a build-dep (PP003)

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -71,7 +71,7 @@ testing = [
 {%- endif %}
 
 [build-system]
-requires = ["setuptools>=42.0.0", "wheel", "setuptools_scm"]
+requires = ["setuptools>=42.0.0", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
# References and relevant issues
Per #76
https://learn.scientific-python.org/development/guides/packaging-classic#PP003


# Description

Removes wheel from build-system requires 
