### PR TITLE
Remove redundant ruff target version (RF002)

### DIFF
--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -132,6 +132,4 @@ exclude = [
     "*vendored*",
     "*_vendor*",
 ]
-
-target-version = "py310"
 fix = true


### PR DESCRIPTION
# References and relevant issues
re #76 

# Description
target-version is set (and properly maintained) by `[project].requires-python` version, remove from ruff config
