### PR TITLE
Monitor github-actions with dependabot (GH 210-212)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,11 +3,22 @@
 # https://til.simonwillison.net/github/dependabot-python-setup
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: monthly
-  groups:
-    python-packages:
-      patterns:
-        - "*"
+  # Monitor Python dependencies
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+  
+  # Monitor GitHub Actions
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/template/.github/{% if install_dependabot %}dependabot.yml{% endif %}.jinja
+++ b/template/.github/{% if install_dependabot %}dependabot.yml{% endif %}.jinja
@@ -4,12 +4,23 @@
 {% raw %}
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: monthly
-  groups:
-    python-packages:
-      patterns:
-        - "*"
+  # Monitor pip dependencies
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+  
+  # Monitor GitHub Actions and propose updates for security and maintenance
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 {% endraw %}


### PR DESCRIPTION
Add dependabot for gh-actions monitoring to both the repo and template.
Conforms to Scientific Python GH 210-212 https://learn.scientific-python.org/development/guides/gha-basic/#updating