### PR TITLE
Use cancel-in-progress and no fast-fail for template CI

### DIFF
--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -15,12 +15,17 @@ on:
       - npe2
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
1. Cancels in progress actions when triggered (such as new commit to branch), intended to prevent people from bogging down runners
2. Turns off fail-fast in case there are OS specific issues that get masked by a faster OS

Surprised we didn't have both of these on before! 
