### PR TITLE
Fix setup-headless-display-action version

### DIFF
--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install Windows OpenGL
-        uses: pyvista/setup-headless-display-action@v4.v2
+        uses: pyvista/setup-headless-display-action@v4.2
         with:
           qt: true
           wm: herbstluftwm


### PR DESCRIPTION
Currently, CI will fail when building a plugin because v4.v2 is not a real thing. This PR fixes it.
