### PR TITLE
Modernize workflow to most recent tools

### DIFF
--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -51,7 +51,7 @@ jobs:
       # tox-conda: https://github.com/tox-dev/tox-conda
       # this runs the platform-specific tests declared in tox.ini
       - name: Test with tox
-        run: uvx --with tox-gh-actions tox 
+        run: uvx --with tox-gh-actions tox
         env:
           PLATFORM: ${{ matrix.platform }}
 


### PR DESCRIPTION
# References and relevant issues


# Description

We should not build packages in release steps. There are two reasons:

1) Build package should be tested on every PR, not fail release if build package fails
2) This is bad practice to execute any code in a task that has tokens required to upload something to pypi. 

Also move setup python to uv, as we advertise using uv for package development. 