### PR TITLE
Add weekly cron job for base and template

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 name: Test plugin template
 
 on:
+  schedule:
+  - cron: "0 0 * * TUE" # every week on Tuesday at midnight
   pull_request:
     branches:
       - main

--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -3,6 +3,8 @@
 name: tests
 
 on:
+  schedule:
+  - cron: "0 0 * * TUE" # every week on Tuesday at midnight
   push:
     branches:
       - main


### PR DESCRIPTION
# Description

This adds a once-per-week scheduled run (cron job) to the github actions. This is the path of least annoyance, because folks can easily ignore the failed jobs. We _could_ create a FAIL_TEMPLATE that gets reported, but this would complicate test_and_deploy and add another file in .github

But, at least folks can learn when dependency updates break their packages

This is a considerably simpler implementation of a cron job compared to #65  (which used reusables and multiple new files)
