### PR TITLE
OIDC tokenless codecov and improved README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,10 @@ You will need to enable the [codecov](https://github.com/apps/codecov) github ap
 for this to work. See [codecov installation docs](https://github.com/apps/codecov/installations/new)
 to install the codecov github app and give it access to your napari plugin repository.
 
+Codecov uploads can use [tokenless OIDC authentication](https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token)
+for public repositories, so no `CODECOV_TOKEN` secret is required.
+The OIDC authentication is automatically handled by GitHub actions, and is required when the coverage branch has been protected via GitHub branch protection rules.
+
 ### Set up automatic deployments
 
 Your new package is also nearly ready to automatically deploy to [PyPI]

--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -24,6 +24,8 @@ jobs:
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 30
+    permissions:
+      id-token: write  # needed for codecov OIDC authentication
     strategy:
       fail-fast: false
       matrix:
@@ -57,6 +59,8 @@ jobs:
 
       - name: Coverage
         uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true  # reliable tokenless codecov uploads
 
   build-and-inspect-package:
     name: Build & inspect package.


### PR DESCRIPTION
# Description

TIL that if a branch (i.e. main branch) is protected by GitHub, then tokenless _will_ fail with codecov. 
In order to accommodate for this, we can just by default use OIDC for the upload. This seems like all around a win, and updates the README to explain this a little more clearly. 
https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token

[Failed action before:](https://github.com/ndev-kit/nbatch/actions/runs/19846323021/job/56864463119)
```
 info - 2025-12-02 03:49:25,550 -- Found 2 coverage files to report
info - 2025-12-02 03:49:25,550 -- > D:\a\nbatch\nbatch\coverage.xml
info - 2025-12-02 03:49:25,552 -- > D:\a\nbatch\nbatch\codecov.exe.SHA256SUM.sig
info - 2025-12-02 03:49:25,774 -- Process Upload complete
error - 2025-12-02 03:49:25,774 -- Upload failed: {"message":"Token required because branch is protected"}
```
[Successful action after adding](https://github.com/ndev-kit/nbatch/actions/runs/19846572119/job/56865130557)
```
info - 2025-12-02 04:01:42,858 -- > D:\a\nbatch\nbatch\coverage.xml
info - 2025-12-02 04:01:42,858 -- > D:\a\nbatch\nbatch\codecov.exe.SHA256SUM.sig
info - 2025-12-02 04:01:43,278 -- Your upload is now processing. When finished, results will be available at: https://app.codecov.io/github/ndev-kit/nbatch/commit/d3a2ddb9481b38a3ed8575c0b7f34c694ce3a25f
info - 2025-12-02 04:01:43,433 -- Process Upload complete
```