### PR TITLE
Explicity use python 3.13 in copier commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ uv tool run --with jinja2-time --with npe2 --python=3.13 copier copy --trust htt
 Using `conda`:
 
 ```bash
-conda create -y --name copier-env python=3.12 copier jinja2-time npe2
+conda create -y --name copier-env python=3.13 copier jinja2-time npe2
 conda activate copier-env
 ```
 


### PR DESCRIPTION
# References and relevant issues

In response to #126, until that gets closed

# Description

- Explicitly sets python 3.13 for quick `uv tool run` command.
- Also updates to python 3.13 for conda env setup
