### PR TITLE
Remove commented out mypy pre-commit

### DIFF
--- a/template/{% if install_precommit %}.pre-commit-config.yaml{% endif %}.jinja
+++ b/template/{% if install_precommit %}.pre-commit-config.yaml{% endif %}.jinja
@@ -16,9 +16,3 @@ repos:
     rev: v0.3.0
     hooks:
       - id: napari-plugin-checks
-  # https://mypy.readthedocs.io/en/stable/
-  # you may wish to add this as well!
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: v1.19.0
-  #   hooks:
-  #     - id: mypy


### PR DESCRIPTION
# Description

I have never seen someone uncomment the mypy pre-commit.

In addition, if someone were to be knowledgeable enough to want mypy or some other type checker, then they will likely also understand how to add it to pre-commit. 

This removes a point of confusion for template users, because its unknown how advanced this is to naive folks.
