### PR TITLE
Add python 3.14 to template and tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        platform: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - platform: windows-latest
+            python-version: "3.12"
+          - platform: macos-latest
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,7 +36,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Setup headless screenL
+      - name: Setup headless screen
+        if: runner.os == 'Linux'
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
         with:
           qt: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup headless screen
-        if: runner.os == 'Linux'
         uses: pyvista/setup-headless-display-action@5bc8de3bc71fcda7a96439571287a554901541a0 # v4.3
         with:
           qt: true

--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -46,7 +46,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: "true"
       - name: Setup headless display
-        if: runner.os == 'Linux'
         uses: pyvista/setup-headless-display-action@v4.3
         with:
           qt: true

--- a/template/.github/workflows/test_and_deploy.yml
+++ b/template/.github/workflows/test_and_deploy.yml
@@ -29,8 +29,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        platform: [ubuntu-latest]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        include:
+          - platform: windows-latest
+            python-version: "3.12"
+          - platform: macos-latest
+            python-version: "3.12"
 
     steps:
       - uses: actions/checkout@v6
@@ -40,7 +45,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: "true"
-      - name: Install Windows OpenGL
+      - name: Setup headless display
+        if: runner.os == 'Linux'
         uses: pyvista/setup-headless-display-action@v4.3
         with:
           qt: true

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
 requires-python = ">=3.10"

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{310,311,312,313}-{linux,macos,windows}
+envlist = py{310,311,312,313,314}-{linux,macos,windows}
 isolated_build=true
 
 [gh-actions]
@@ -9,6 +9,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 [gh-actions:env]
 PLATFORM =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 recreate = true
 skipsdist = true
-envlist = py3{10,11,12,13}
+envlist = py3{10,11,12,13,14}
 toxworkdir = /tmp/.tox
 
 [testenv]


### PR DESCRIPTION
# References and relevant issues

First PR pulled out of #137

# Description

Adds 3.14 to tox and CI and starts to narrow down CI matrix by only running all pythons on ubuntu and just the middle python for windows and macos
