### PR TITLE
Clean up the tasks python script

### DIFF
--- a/_tasks.py
+++ b/_tasks.py
@@ -6,15 +6,19 @@ import sys
 from argparse import ArgumentParser
 from pathlib import Path
 
+from npe2 import PluginManifest
+from pydantic import ValidationError
+
 # Ensure UTF-8 output on Windows where the default encoding (cp1252) cannot
 # encode the Unicode symbols (✔ ℹ ⚠ ✗ 🚀) used in the output below.
-if hasattr(sys.stdout, 'reconfigure'):
-    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+stdout_reconfigure = getattr(sys.stdout, 'reconfigure', None)
+if callable(stdout_reconfigure):
+    stdout_reconfigure(encoding='utf-8', errors='replace')
 
 
-# ANSI color codes for better visual output
 class Colors:
     """ANSI color codes for terminal output."""
+
     BLUE = '\033[94m'
     GREEN = '\033[92m'
     YELLOW = '\033[93m'
@@ -62,35 +66,19 @@ def pypi_package_name_compliance(plugin_name):
 
 def validate_manifest(module_name, project_directory):
     """Validate the new plugin repository against napari requirements."""
-    try:
-        from npe2 import PluginManifest
-    except ImportError:
-        print(Colors.warning('npe2 is not installed. Skipping manifest validation.'))
-        return True
-
-    current_directory = Path('.').absolute()
-    if (
-        current_directory.match(project_directory)
-        and not Path(project_directory).is_absolute()
-    ):
-        project_directory = current_directory
-
-    path = Path(project_directory) / 'src' / Path(module_name) / 'napari.yaml'
-
-    valid = False
+    # copier passes _copier_conf.dst_path (absolute); resolve() handles both
+    # absolute and relative paths safely regardless of working directory.
+    path = Path(project_directory).resolve() / 'src' / module_name / 'napari.yaml'
     try:
         pm = PluginManifest.from_file(path)
-        msg = f"Manifest for '{pm.display_name or pm.name}' is valid!"
-        valid = True
-    except PluginManifest.ValidationError as err:
+    except ValidationError as err:
         print(Colors.error(f'Invalid manifest: {err}'))
         sys.exit(1)
     except (FileNotFoundError, PermissionError, OSError) as err:
         print(Colors.error(f'Failed to read {path!r}. {type(err).__name__}: {err}'))
         sys.exit(1)
     else:
-        print(Colors.success(msg))
-        return valid
+        print(Colors.success(f"Manifest for '{pm.display_name or pm.name}' is valid!"))
 
 
 def initialize_new_repository(
@@ -106,26 +94,6 @@ def initialize_new_repository(
     print(Colors.info("Setting up your plugin repository..."))
     print("="*50 + "\n")
 
-    # Configure git to suppress line ending warnings
-    git_env = os.environ.copy()
-    git_env['GIT_CONFIG_GLOBAL'] = os.devnull  # Prevent reading global config
-
-    # Configure git line ending settings quietly
-    # devnull to suppress output
-    if os.name == 'nt':  # if on Windows, configure git line ending characters
-        subprocess.run(
-            ['git', 'config', '--global', 'core.autocrlf', 'true'],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    else:  # for Linux and Mac
-        subprocess.run(
-            ['git', 'config', '--global', 'core.autocrlf', 'input'],
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-
-    # Initialize git repository
     try:
         print(Colors.info("Initializing git repository..."))
         subprocess.run(
@@ -134,94 +102,65 @@ def initialize_new_repository(
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+        # Use symbolic-ref rather than 'git checkout -b main': the checkout
+        # command fails with "branch 'main' already exists" when the user's
+        # global init.defaultBranch is already set to 'main' (GitHub's
+        # recommended default).  symbolic-ref writes the HEAD pointer directly
+        # and is idempotent across all git versions.
         subprocess.run(
-            ['git', 'checkout', '-b', 'main'],
+            ['git', 'symbolic-ref', 'HEAD', 'refs/heads/main'],
             check=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        print(Colors.success("Git repository initialized"))
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-        print(Colors.error(f'Error in git initialization: {e}'))
-        return _generate_manual_setup_message(plugin_name, plugin_directory, github_repository_url, github_username_or_organization)
-
-    if install_precommit is True:
-        print(Colors.info("Setting up pre-commit hooks..."))
-        # Try to install and update pre-commit
-        try:
-            # Check if we're in a uv environment to use uv's pip if available
-            in_uv_env = 'UV_PROJECT_ENVIRONMENT' in os.environ or subprocess.run(
-                ['uv', '--version'],
-                capture_output=True,
-                text=True
-            ).returncode == 0
-
-            if in_uv_env:
-                # Use uv to install pre-commit
-                subprocess.run(
-                    ['uv', 'pip', 'install', 'pre-commit'],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=True,
-                )
-            else:
-                # Use regular pip
-                subprocess.run(
-                    ['python', '-m', 'pip', 'install', 'pre-commit'],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=True,
-                )
-
-            # Update pre-commit hooks
-            subprocess.run(
-                ['pre-commit', 'autoupdate'],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-
-            # Stage files and run pre-commit formatting
-            subprocess.run(
-                ['git', 'add', '.'],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-            subprocess.run(
-                ['pre-commit', 'run', 'ruff-check', '-a'],
-                capture_output=True,
-                check=False,
-            )
-            subprocess.run(
-                ['pre-commit', 'run', 'ruff-format', '-a'],
-                capture_output=True,
-                check=False,
-            )
-            print(Colors.success("Pre-commit hooks configured"))
-        except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-            print(Colors.warning(f'Could not install pre-commit (this is optional): {e}'))
-
-    # Create initial commit
-    try:
-        print(Colors.info("Creating initial commit..."))
-        subprocess.run(['git', 'add', '.'], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ['git', 'config', 'core.autocrlf', 'true' if os.name == 'nt' else 'input'],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ['git', 'config', 'core.safecrlf', 'false'],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        print(Colors.info('Creating initial commit...'))
+        subprocess.run(
+            ['git', 'add', '.'],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        # Pass identity via -c flags so this never fails on machines that have
+        # no global user.email/user.name configured (e.g. fresh CI runners).
         subprocess.run(
             [
                 'git',
                 '-c', 'user.email=template@napari.org',
                 '-c', 'user.name=napari template',
-                'commit', '-q', '-m', 'initial commit',
+                'commit',
+                '-q',
+                '-m',
+                'initial commit',
             ],
             check=True,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        print(Colors.success("Initial commit created"))
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as e:
-        print(Colors.error(f'Error creating initial git commit: {e}'))
-        return _generate_manual_setup_message(plugin_name, plugin_directory, github_repository_url, github_username_or_organization)
+        print(Colors.success("Git repository initialized with initial commit"))
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as err:
+        print(Colors.error(f'Error in git initialization: {err}'))
+        return _generate_manual_setup_message(
+            plugin_name,
+            plugin_directory,
+            github_repository_url,
+            github_username_or_organization,
+        )
 
-    # Ensure full read/write/execute permissions for .git files on Windows
     if os.name == 'nt':
+        # Remove hidden/read-only attributes that Windows sometimes sets on
+        # the .git directory, which can confuse tools that inspect the tree.
         with contextlib.suppress(Exception):
             subprocess.run(
                 ['attrib', '-h', '-r', '.git', '/s', '/d'],
@@ -229,24 +168,69 @@ def initialize_new_repository(
                 stderr=subprocess.DEVNULL,
             )
 
-    # Install pre-commit hooks after initial commit
+    pre_commit_command = [sys.executable, '-m', 'pre_commit']
+    pre_commit_available = False
+
     if install_precommit is True:
+        # pre-commit is optional: a failure here warns but does not abort.
+        print(Colors.info('Setting up pre-commit hooks...'))
         try:
             subprocess.run(
-                ['pre-commit', 'install'],
+                [sys.executable, '-m', 'pip', 'install', 'pre-commit'],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )
-            print(Colors.success("Pre-commit hooks installed"))
+            subprocess.run(
+                [*pre_commit_command, '--version'],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            pre_commit_available = True
+            print(Colors.success('Pre-commit is available'))
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError) as err:
+            print(Colors.warning(f'Could not install pre-commit (this is optional): {err}'))
+
+    if install_precommit is True and pre_commit_available:
+        try:
+            subprocess.run(
+                [*pre_commit_command, 'install'],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            print(Colors.success('Pre-commit hooks installed'))
         except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             print(Colors.warning('Could not install pre-commit hooks (this is optional)'))
 
-    return _generate_next_steps_message(plugin_name, plugin_directory, github_repository_url, github_username_or_organization)
+    return _generate_next_steps_message(
+        plugin_name,
+        plugin_directory,
+        github_repository_url,
+        github_username_or_organization,
+    )
 
 
-def _generate_manual_setup_message(plugin_name, plugin_directory, github_repository_url, github_username_or_organization):
+def _resolved_github_url(plugin_name, github_repository_url, github_username_or_organization):
+    """Return the resolved GitHub repo URL, or None if not yet known."""
+    if github_repository_url != 'provide later':
+        return f'https://github.com/{github_username_or_organization}/{plugin_name}'
+    return None
+
+
+def _generate_manual_setup_message(
+    plugin_name,
+    plugin_directory,
+    github_repository_url,
+    github_username_or_organization,
+):
     """Generate message for manual setup when git initialization fails."""
+    gh_url = _resolved_github_url(
+        plugin_name,
+        github_repository_url,
+        github_username_or_organization
+    )
     msg = f"""
 {Colors.warning('Git initialization had issues. Please set up manually:')}
 
@@ -259,16 +243,17 @@ def _generate_manual_setup_message(plugin_name, plugin_directory, github_reposit
     git commit -m 'initial commit'
 
 {Colors.step(3, 4, 'Install your plugin in development mode:')}
-    pip install -e .[all]
+    pip install -e ".[all]" --group dev
 {Colors.info('This installs your plugin with napari and default Qt bindings in editable mode.')}
+{Colors.info('You can run tests directly with pytest or tox after installation.')}
 
 {Colors.step(4, 4, 'Create and link GitHub repository:')}"""
 
-    if github_repository_url != 'provide later':
+    if gh_url:
         msg += f"""
-    Create at: https://github.com/{github_username_or_organization}/{plugin_name}
+    Create at: {gh_url}
     Then run:
-        git remote add origin https://github.com/{github_username_or_organization}/{plugin_name}.git
+        git remote add origin {gh_url}.git
         git push -u origin main"""
     else:
         msg += """
@@ -278,8 +263,18 @@ def _generate_manual_setup_message(plugin_name, plugin_directory, github_reposit
     return msg
 
 
-def _generate_next_steps_message(plugin_name, plugin_directory, github_repository_url, github_username_or_organization):
+def _generate_next_steps_message(
+    plugin_name,
+    plugin_directory,
+    github_repository_url,
+    github_username_or_organization,
+):
     """Generate the next steps message after successful initialization."""
+    gh_url = _resolved_github_url(
+        plugin_name,
+        github_repository_url,
+        github_username_or_organization
+    )
 
     msg = f"""
 {"="*50}
@@ -287,26 +282,27 @@ def _generate_next_steps_message(plugin_name, plugin_directory, github_repositor
 {"="*50}
 {Colors.step(1, 5, 'Install your plugin in development mode:')}
     cd {plugin_directory}
-    pip install -e .[all]
+    uv pip install -e ".[all]" --group dev
 
 {Colors.info('This installs your plugin with napari and default Qt bindings in editable mode.')}
+{Colors.info('You can run tests directly with pytest or tox after installation.')}
 """
 
-    if github_repository_url != 'provide later':
+    if gh_url:
         msg += f"""
 {Colors.step(2, 5, f"Create a GitHub repository named '{plugin_name}':")}
-    https://github.com/{github_username_or_organization}/{plugin_name}
+    {gh_url}
 
 {Colors.step(3, 5, 'Link and push to GitHub:')}
-    git remote add origin https://github.com/{github_username_or_organization}/{plugin_name}.git
+    git remote add origin {gh_url}.git
     git push -u origin main
 
 {Colors.step(4, 5, 'Review your project URLs in pyproject.toml:')}
     The following URLs will appear on the napari hub:
-    • Bug Tracker: https://github.com/{github_username_or_organization}/{plugin_name}/issues
-    • Documentation: https://github.com/{github_username_or_organization}/{plugin_name}#README.md
-    • Source Code: https://github.com/{github_username_or_organization}/{plugin_name}
-    • User Support: https://github.com/{github_username_or_organization}/{plugin_name}/issues
+    • Bug Tracker: {gh_url}/issues
+    • Documentation: {gh_url}#README.md
+    • Source Code: {gh_url}
+    • User Support: {gh_url}/issues
 """
     else:
         msg += f"""
@@ -372,11 +368,7 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    # Since bool("False") returns True, we need to check the actual string value
-    if str(args.install_precommit).lower() == 'true':
-        install_precommit = True
-    else:
-        install_precommit = False
+    install_precommit = str(args.install_precommit).lower() == 'true'
     module_name_pep8_compliance(args.module_name)
     pypi_package_name_compliance(args.plugin_name)
     validate_manifest(args.module_name, args.project_directory)


### PR DESCRIPTION
# References and relevant issues

Spun out of #137. Ideally includes #141 to double check it works with the new tests, but leaving out for now to make review easier. 

# Description

This cleans up `_tasks.py` in various ways but has a few _functional_ changes that are important and worth highlighting:

1. it assumes npe2 is there, because the requirements contain it, so simplifies some try/excepts
2. relies on copier's cleaner path logic to reduce some conditionals
3. uses modern git commands that assume a head named `main` to prevent any aborts if that branch already exists (like it does when the template is rerun)
4. **Does not modify the users GLOBAL git config**. LOL WHAT, how did we ever allow this? Now just changes the local git config for `autocrlf` stuff


